### PR TITLE
fix(nav): correct vivliostyle.org Tutorials/FAQ links to drop /en/ prefix

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -6,6 +6,7 @@
 import Breadcrumb from '../components/Breadcrumb.astro';
 import SearchBox from '../components/SearchBox.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
+import { VIVLIOSTYLE_ORG_LINKS } from '../lib/external-links';
 
 interface Props {
   title: string;
@@ -49,7 +50,7 @@ const navLinks = {
   ],
   tutorial: {
     label: navLabels.tutorial,
-    href: isJa ? 'https://vivliostyle.org/ja/tutorials/' : 'https://vivliostyle.org/en/tutorials/',
+    href: isJa ? VIVLIOSTYLE_ORG_LINKS.tutorials.ja : VIVLIOSTYLE_ORG_LINKS.tutorials.en,
     external: true,
   },
   cookbook: {
@@ -71,7 +72,7 @@ const navLinks = {
   },
   faq: {
     label: navLabels.faq,
-    href: isJa ? 'https://vivliostyle.org/ja/faq/' : 'https://vivliostyle.org/en/faq/',
+    href: isJa ? VIVLIOSTYLE_ORG_LINKS.faq.ja : VIVLIOSTYLE_ORG_LINKS.faq.en,
     external: true,
   },
 };

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -1,0 +1,19 @@
+/**
+ * vivliostyle.org(マーケティングサイト、別リポジトリ)へのリンク。
+ *
+ * 英語ページにはロケールプレフィックスが無く、日本語ページのみ /ja/ を使う
+ * (例: /tutorials/ が英語版、/ja/tutorials/ が日本語版。/en/tutorials/ は
+ * 存在せず404になる)。この非対称な構造を「揃えよう」として /en/ を足すと
+ * 壊れるので、変更前に必ず実際のURLで確認すること。
+ * 参照: https://github.com/vivliostyle/docs2.vivliostyle.org/issues/32
+ */
+export const VIVLIOSTYLE_ORG_LINKS = {
+  tutorials: {
+    en: 'https://vivliostyle.org/tutorials/',
+    ja: 'https://vivliostyle.org/ja/tutorials/',
+  },
+  faq: {
+    en: 'https://vivliostyle.org/faq/',
+    ja: 'https://vivliostyle.org/ja/faq/',
+  },
+} as const;

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -5,6 +5,7 @@
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import LanguageSwitcher from '../../components/LanguageSwitcher.astro';
 import { getCollection } from 'astro:content';
+import { VIVLIOSTYLE_ORG_LINKS } from '../../lib/external-links';
 
 // VFMでコンバートされたドキュメントを取得
 let indexDoc = null;
@@ -71,7 +72,7 @@ const description = indexDoc?.data?.description || 'Official documentation for V
     </div>
     <ul class="sidebar-flat">
       <li>
-        <a href="https://vivliostyle.org/en/tutorials/" target="_blank" rel="noopener noreferrer">Tutorials</a>
+        <a href={VIVLIOSTYLE_ORG_LINKS.tutorials.en} target="_blank" rel="noopener noreferrer">Tutorials</a>
       </li>
     </ul>
 
@@ -103,7 +104,7 @@ const description = indexDoc?.data?.description || 'Official documentation for V
 
     <ul class="sidebar-flat">
       <li>
-        <a href="https://vivliostyle.org/en/faq/" target="_blank" rel="noopener noreferrer">FAQ</a>
+        <a href={VIVLIOSTYLE_ORG_LINKS.faq.en} target="_blank" rel="noopener noreferrer">FAQ</a>
       </li>
     </ul>
   </nav>

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -5,6 +5,7 @@
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import LanguageSwitcher from '../../components/LanguageSwitcher.astro';
 import { getCollection } from 'astro:content';
+import { VIVLIOSTYLE_ORG_LINKS } from '../../lib/external-links';
 
 // VFMでコンバートされたドキュメントを取得
 let indexDoc = null;
@@ -71,7 +72,7 @@ const description = indexDoc?.data?.description || 'Vivliostyle公式ドキュ�
     </div>
     <ul class="sidebar-flat">
       <li>
-        <a href="https://vivliostyle.org/ja/tutorials/" target="_blank" rel="noopener noreferrer">チュートリアル</a>
+        <a href={VIVLIOSTYLE_ORG_LINKS.tutorials.ja} target="_blank" rel="noopener noreferrer">チュートリアル</a>
       </li>
     </ul>
 
@@ -103,7 +104,7 @@ const description = indexDoc?.data?.description || 'Vivliostyle公式ドキュ�
 
     <ul class="sidebar-flat">
       <li>
-        <a href="https://vivliostyle.org/ja/faq/" target="_blank" rel="noopener noreferrer">FAQ</a>
+        <a href={VIVLIOSTYLE_ORG_LINKS.faq.ja} target="_blank" rel="noopener noreferrer">FAQ</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
## Summary

vivliostyle.org's English pages have no locale prefix (only Japanese uses `/ja/`), so the global nav's and English home page's Tutorials/FAQ links (`/en/tutorials/`, `/en/faq/`) both 404.

Verified live:
- `https://vivliostyle.org/tutorials/` → 200
- `https://vivliostyle.org/faq/` → 200
- `https://vivliostyle.org/ja/tutorials/` → 200
- `https://vivliostyle.org/ja/faq/` → 200
- `https://vivliostyle.org/en/tutorials/` → 404
- `https://vivliostyle.org/en/faq/` → 404

This URL was previously correct in `DocsLayout.astro` (commit 7a653d6) but got reverted to the broken `/en/` form in commit 8edd101 while "aligning" it with the home sidebar (`src/pages/en/index.astro`), which had never been correct in the first place. Since the same value was duplicated across three files, one being fixed didn't help — and it later got silently reverted anyway.

## Changes

- Added `src/lib/external-links.ts`: single source of truth for these URLs, with a comment explaining the no-`/en/`-prefix rule so it isn't "corrected" back to a 404 again
- Updated `DocsLayout.astro` (global nav), `src/pages/en/index.astro`, and `src/pages/ja/index.astro` to import from it instead of hardcoding the URL in three places

Fixes #32

## Test plan

- [x] `npm run dev`, confirmed all four links (global nav en/ja, home sidebar en/ja) render the corrected URLs
- [x] Verified the corrected URLs return 200 and the old `/en/` URLs return 404 against the live site