### PR TITLE
chore(ci): bump Node.js from 20 to 22 in workflows

### DIFF
--- a/.github/workflows/build-formats.yml
+++ b/.github/workflows/build-formats.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/build-formats.yml
+++ b/.github/workflows/build-formats.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          # astro 6.x が要求する Node.js >=22.12.0 を満たすため 22.12 系に固定
+          # （パッチバージョンは自動追従、22.12.0 未満へのフォールバックを防ぐ）
+          node-version: '22.12'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          # astro 6.x が要求する Node.js >=22.12.0 を満たすため 22.12 系に固定
+          # （パッチバージョンは自動追従、22.12.0 未満へのフォールバックを防ぐ）
+          node-version: '22.12'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## 概要
- `deploy.yml` / `build-formats.yml` の Node.js バージョンを 20 → 22 に引き上げ

## 背景
- astro 6.x（#38）が Node.js >=22.12.0 を要求するため、5→6のメジャーアップグレードに必要な前提変更
- `@vivliostyle/cli` の `engines.node` は `^20.0.0 || >=22.0.0` であり、22系との互換性は問題なし

## テスト計画
- [ ] このPRのCI（deploy.yml）がNode 22でビルド成功することを確認
- [ ] #38 マージ後、mainの通常ビルドも成功することを確認